### PR TITLE
Fix broken htcondor metapackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About htcondor
-==============
+About htcondor-build
+====================
 
 Home: http://htcondor.org/
 
@@ -91,10 +91,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libcondor_utils-green.svg)](https://anaconda.org/conda-forge/libcondor_utils) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcondor_utils.svg)](https://anaconda.org/conda-forge/libcondor_utils) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcondor_utils.svg)](https://anaconda.org/conda-forge/libcondor_utils) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcondor_utils.svg)](https://anaconda.org/conda-forge/libcondor_utils) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-python--htcondor-green.svg)](https://anaconda.org/conda-forge/python-htcondor) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-htcondor.svg)](https://anaconda.org/conda-forge/python-htcondor) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-htcondor.svg)](https://anaconda.org/conda-forge/python-htcondor) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-htcondor.svg)](https://anaconda.org/conda-forge/python-htcondor) |
 
-Installing htcondor
-===================
+Installing htcondor-build
+=========================
 
-Installing `htcondor` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `htcondor-build` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -151,17 +151,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating htcondor-feedstock
-===========================
+Updating htcondor-build-feedstock
+=================================
 
-If you would like to improve the htcondor recipe or build a new
+If you would like to improve the htcondor-build recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/htcondor-feedstock are
+Note that all branches in the conda-forge/htcondor-build-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     - paths.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:
@@ -266,10 +266,13 @@ outputs:
 
   - name: htcondor
     requirements:
+      host:
+        - python
       run:
         - {{ pin_subpackage('htcondor-classads', exact=True) }}
         - {{ pin_subpackage('htcondor-procd', exact=True) }}
         - {{ pin_subpackage('libcondor_utils', exact=True) }}
+        - python
         - {{ pin_subpackage('python-htcondor', exact=True) }}
         - {{ pin_subpackage('htcondor-utils', exact=True) }}
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,11 @@
 {% set uversion = version|replace('.', '_') %}
 
 package:
-  name: "{{ name|lower }}"
+  # the top-level package should be called `htcondor`, but
+  # because the metapackage needs to specify host dependencies
+  # we have to rename the top-level package so that conda-build
+  # doesn't get confused
+  name: "{{ name|lower }}-build"
   version: "{{ version }}"
 
 source:


### PR DESCRIPTION
This PR fixes the broken `htcondor` metapackage by adding `python` as a `host` and `run` dependency, meaning we get a separate `htcondor` package for each `python-htcondor` build.

This has required renaming the top-level recipe, so that the top-level build dependencies don't clash with those of the `htcondor` metapackage output.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
