### PR TITLE
Remove openmp_impl

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:
@@ -143,7 +143,6 @@ outputs:
         - {{ pin_subpackage('htcondor-classads', exact=True) }}
         - krb5
         - munge
-        - openmp_impl  # [linux]
         - openssl
         - pcre
         - voms
@@ -180,7 +179,6 @@ outputs:
         - {{ pin_subpackage("libcondor_utils", exact=True) }}
         - libcurl
         - libuuid  # [unix]
-        - openmp_impl  # [linux]
         - voms
     files:
       - bin/condor*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ requirements:
     - pcre
     - sqlite
     - voms
+    - libgomp  # [linux]
 
 outputs:
   - name: htcondor-classads

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,6 @@ requirements:
     - pcre
     - sqlite
     - voms
-    - libgomp  # [linux]
 
 outputs:
   - name: htcondor-classads
@@ -139,6 +138,7 @@ outputs:
         - openssl
         - pcre
         - voms
+        - libgomp  # [linux]
       run:
         - gct
         - {{ pin_subpackage('htcondor-classads', exact=True) }}
@@ -173,6 +173,7 @@ outputs:
         - {{ pin_subpackage("htcondor-procd", exact=True) }}
         - {{ pin_subpackage("libcondor_utils", exact=True) }}
         - libuuid  # [unix]
+        - libgomp  # [linux]
         - voms
       run:
         - {{ pin_subpackage("htcondor-classads", exact=True) }}


### PR DESCRIPTION
This PR undoes parts of #5 that include `openmp_impl` in the recipe, since that package is now marked as `broken`.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
