### PR TITLE
Fix version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "htcondor" %}
 {% set version = "8_9_7" %}
-{% set uversion = version|replace('.', '_') %}
 
 package:
   # the top-level package should be called `htcondor`, but
@@ -8,10 +7,10 @@ package:
   # we have to rename the top-level package so that conda-build
   # doesn't get confused
   name: {{ name|lower }}-build
-  version: {{ version }}
+  version: {{ version|replace('_', '.') }}
 
 source:
-  url: https://github.com/{{ name }}/{{ name }}/archive/V{{ uversion }}.tar.gz
+  url: https://github.com/{{ name }}/{{ name }}/archive/V{{ version }}.tar.gz
   sha256: bd3f208061a38e3602bcb15ba3bb2d24e60d00b5a0d962edcbf21e0119ba0c8e
   patches:
     # set C_PYTHONARCHLIB for python
@@ -26,7 +25,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 1
+  number: 2
   skip: true  # [not linux]
 
 requirements:
@@ -153,7 +152,7 @@ outputs:
       - lib/libcondor_utils*
     test:
       commands:
-        - test -f ${PREFIX}/lib/libcondor_utils_{{ uversion }}${SHLIB_EXT}  # [unix]
+        - test -f ${PREFIX}/lib/libcondor_utils_{{ version }}${SHLIB_EXT}  # [unix]
     about:
       home: http://htcondor.org/
       doc_url: https://htcondor.readthedocs.io/


### PR DESCRIPTION
This PR fixes the version numbering. The new regro version updates declare the version using the underscores, so we need to undo that (the opposite of what we used to do).

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
