### PR TITLE
Include htcondor_cli in python-htcondor

### DIFF
--- a/recipe/build-python.sh
+++ b/recipe/build-python.sh
@@ -47,3 +47,6 @@ cmake --build bindings/python --parallel ${CPU_COUNT} --verbose
 # install
 cmake --build src/python-bindings --parallel ${CPU_COUNT} --verbose --target install
 cmake --build bindings/python --parallel ${CPU_COUNT} --verbose --target install
+
+# install the htcondor_cli package (but not the actual CLI script)
+cp -r ${SRC_DIR}/src/condor_tools/htcondor_cli ${SP_DIR}/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -304,6 +304,7 @@ outputs:
         - htcondor.dags
         - htcondor.htchirp
         - htcondor.personal
+        - htcondor_cli
     about:
       home: http://htcondor.org/
       doc_url: https://htcondor.readthedocs.io/
@@ -320,6 +321,8 @@ outputs:
 
   - name: htcondor
     build:
+      entry_points:
+        - htcondor = htcondor_cli.cli:main
       skip: true  # [python_impl != 'cpython']
     requirements:
       host:
@@ -332,10 +335,12 @@ outputs:
         - {{ pin_subpackage('htcondor-utils', exact=True) }}
     test:
       imports:
-        - htcondor
         - classad
+        - htcondor
+        - htcondor_cli
       commands:
         - condor_q --version
+        - htcondor --help
 
 about:
   home: http://htcondor.org/


### PR DESCRIPTION
This PR updates the build to include the `htcondor_cli` module and script as follows:

- include the `htcondor_cli` Python package in the `python-htcondor` package
- include (dynamically create) the `bin/htcondor` CLI in the `htcondor` package

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
