### PR TITLE
Add htcondor-cli package

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-htcondor-green.svg)](https://anaconda.org/conda-forge/htcondor) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/htcondor.svg)](https://anaconda.org/conda-forge/htcondor) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/htcondor.svg)](https://anaconda.org/conda-forge/htcondor) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/htcondor.svg)](https://anaconda.org/conda-forge/htcondor) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-htcondor--classads-green.svg)](https://anaconda.org/conda-forge/htcondor-classads) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/htcondor-classads.svg)](https://anaconda.org/conda-forge/htcondor-classads) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/htcondor-classads.svg)](https://anaconda.org/conda-forge/htcondor-classads) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/htcondor-classads.svg)](https://anaconda.org/conda-forge/htcondor-classads) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-htcondor--cli-green.svg)](https://anaconda.org/conda-forge/htcondor-cli) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/htcondor-cli.svg)](https://anaconda.org/conda-forge/htcondor-cli) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/htcondor-cli.svg)](https://anaconda.org/conda-forge/htcondor-cli) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/htcondor-cli.svg)](https://anaconda.org/conda-forge/htcondor-cli) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-htcondor--utils-green.svg)](https://anaconda.org/conda-forge/htcondor-utils) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/htcondor-utils.svg)](https://anaconda.org/conda-forge/htcondor-utils) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/htcondor-utils.svg)](https://anaconda.org/conda-forge/htcondor-utils) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/htcondor-utils.svg)](https://anaconda.org/conda-forge/htcondor-utils) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libcondor_utils-green.svg)](https://anaconda.org/conda-forge/libcondor_utils) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcondor_utils.svg)](https://anaconda.org/conda-forge/libcondor_utils) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcondor_utils.svg)](https://anaconda.org/conda-forge/libcondor_utils) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcondor_utils.svg)](https://anaconda.org/conda-forge/libcondor_utils) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-python--htcondor-green.svg)](https://anaconda.org/conda-forge/python-htcondor) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/python-htcondor.svg)](https://anaconda.org/conda-forge/python-htcondor) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/python-htcondor.svg)](https://anaconda.org/conda-forge/python-htcondor) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/python-htcondor.svg)](https://anaconda.org/conda-forge/python-htcondor) |
@@ -175,16 +176,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `htcondor, htcondor-classads, htcondor-utils, libcondor_utils, python-htcondor` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `htcondor, htcondor-classads, htcondor-cli, htcondor-utils, libcondor_utils, python-htcondor` can be installed with `conda`:
 
 ```
-conda install htcondor htcondor-classads htcondor-utils libcondor_utils python-htcondor
+conda install htcondor htcondor-classads htcondor-cli htcondor-utils libcondor_utils python-htcondor
 ```
 
 or with `mamba`:
 
 ```
-mamba install htcondor htcondor-classads htcondor-utils libcondor_utils python-htcondor
+mamba install htcondor htcondor-classads htcondor-cli htcondor-utils libcondor_utils python-htcondor
 ```
 
 It is possible to list all of the versions of `htcondor` available on your platform with `conda`:

--- a/recipe/build-htcondor-cli.sh
+++ b/recipe/build-htcondor-cli.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -eux
+
+HTCONDOR_CLI_SRC_DIR="${SRC_DIR}/src/condor_tools"
+
+# install the htcondor_cli Python library
+mkdir -pv "${SP_DIR}/"
+cp -rv "${HTCONDOR_CLI_SRC_DIR}/htcondor_cli" "${SP_DIR}/"
+
+# install the console script
+mkdir -pv "${PREFIX}/bin/"
+install -m 0755 -v "${HTCONDOR_CLI_SRC_DIR}/htcondor" "${PREFIX}/bin/"
+
+# create some ad-hoc metadata
+DIST_INFO_DIR="${SP_DIR}/${PKG_NAME/-/_}-${PKG_VERSION/-/_}.dist-info"
+mkdir -pv ${DIST_INFO_DIR}/
+cat <<EOF >${DIST_INFO_DIR}/METADATA
+Metadata-Version: 2.3
+Name: ${PKG_NAME}
+Version: ${PKG_VERSION}
+Summary: HTCondor CLI tool
+Home-page: https://htcondor.org
+License: Apache-2.0
+Provides: ${PKG_NAME}
+EOF
+cat <<EOF >${DIST_INFO_DIR}/INSTALLER
+HTCondor on conda-forge
+EOF
+cat <<EOF >${DIST_INFO_DIR}/entry_points.txt
+[console_scripts]
+htcondor = htcondor_cli.cli:main
+EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 2
+  number: 3
   skip: true  # [win]
 
 requirements:
@@ -309,6 +309,37 @@ outputs:
         the same C++ libraries as HTCondor itself, meaning they have
         nearly the same behavior as the command line tools.
 
+  - name: htcondor-cli
+    script: build-htcondor-cli.sh
+    build:
+      skip: true  # [python_impl != 'cpython']
+    requirements:
+      build:
+        # extras for cross-compilation
+        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+        - python                              # [build_platform != target_platform]
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('python-htcondor', exact=True) }}
+    files:
+      # console script
+      - bin/htcondor
+      # python library
+      - {{ SP_DIR }}/htcondor_cli/
+      # metadata
+      - {{ SP_DIR }}/htcondor_cli-{{ version }}.dist-info/
+    test:
+      requires:
+        - pip
+      imports:
+        - htcondor_cli
+      commands:
+        - python -m pip check
+        - python -m pip show htcondor-cli
+        - htcondor --help
+
   - name: htcondor
     build:
       skip: true  # [python_impl != 'cpython']
@@ -316,17 +347,20 @@ outputs:
       host:
         - python
       run:
-        - {{ pin_subpackage('htcondor-classads', exact=True) }}
-        - {{ pin_subpackage('libcondor_utils', exact=True) }}
         - python
-        - {{ pin_subpackage('python-htcondor', exact=True) }}
+        - {{ pin_subpackage('htcondor-classads', exact=True) }}
+        - {{ pin_subpackage('htcondor-cli', exact=True) }}
         - {{ pin_subpackage('htcondor-utils', exact=True) }}
+        - {{ pin_subpackage('libcondor_utils', exact=True) }}
+        - {{ pin_subpackage('python-htcondor', exact=True) }}
     test:
       imports:
-        - htcondor
         - classad
+        - htcondor
+        - htcondor_cli
       commands:
         - condor_q --version
+        - htcondor --help
 
 about:
   home: http://htcondor.org/


### PR DESCRIPTION
This PR adds a new `htcondor-cli` package that bundles the `htcondor_cli` Python package. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
