### PR TITLE
Fix `files` directory globs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -193,7 +193,7 @@ outputs:
     files:
       - bin/condor*
       - bin/*gahp
-      - etc/condor/*
+      - etc/condor/
       - etc/init.d/condor*
       - etc/examples/condor
       - etc/conda/*activate.d/*_condor.sh
@@ -201,7 +201,7 @@ outputs:
       - lib/*.jar
       - lib/libcondorapi*
       - lib/libchirp*
-      - libexec/condor/*
+      - libexec/condor/
       - share/man/man1/condor*.1
     test:
       commands:


### PR DESCRIPTION
This PR fixes #220 by updating directory entries in `files:` to not use a wildcard (which is non-recursive), instead just specify the directory (which is recursive).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
