### PR TITLE
Strip debug symbols from installed binaries

### DIFF
--- a/recipe/build-python.sh
+++ b/recipe/build-python.sh
@@ -32,3 +32,8 @@ cmake --build bindings/python --parallel ${CPU_COUNT} --verbose
 # install
 cmake --build src/python-bindings --parallel ${CPU_COUNT} --verbose --target install
 cmake --build bindings/python --parallel ${CPU_COUNT} --verbose --target install
+
+# strip debug symbols from the installed extension modules (see condor_strip
+# in common.sh); the bindings are built RelWithDebInfo (-g3) just like the
+# rest of HTCondor.
+find "${SP_DIR}" -type f -name "*.so" | condor_strip

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,6 +29,13 @@ cmake --build . --parallel ${CPU_COUNT} --verbose
 # install
 cmake --build . --parallel ${CPU_COUNT} --verbose --target install
 
+# strip debug symbols from the binaries we just installed (see condor_strip
+# in common.sh).  Use the CMake install manifest so we only strip files that
+# HTCondor installed, not the host dependencies that also live in ${PREFIX}.
+if [ -f install_manifest.txt ]; then
+  condor_strip < install_manifest.txt
+fi
+
 # -- POST
 
 # move the man page for classads into the right directory

--- a/recipe/common.sh
+++ b/recipe/common.sh
@@ -58,26 +58,26 @@ HTCONDOR_CMAKE_ARGS="
 # debug info, which is a significant size overhead.  Upstream expects the
 # packaging system to do the stripping ("package may strip the info").
 #
-# Reads a newline-separated list of paths on stdin and strips any that are
-# ELF/Mach-O binaries (other paths, e.g. scripts and data files, are left
-# untouched).  Uses the toolchain ${STRIP} so it also works when cross
-# compiling.
+# Reads a newline-separated list of paths on stdin and strips debug symbols
+# from each one.  We deliberately do not use `file` to detect binaries: it
+# is not installed in the conda-forge Linux build image, which would make
+# the detection silently match nothing.  Instead we let the toolchain
+# ${STRIP} reject non-object files (errors are ignored) and pick the strip
+# mode from the target platform.  Using ${STRIP} also keeps this correct
+# when cross compiling.
 condor_strip() {
   local _strip="${STRIP:-strip}"
+  local _stripopt
+  if [[ "${target_platform}" == osx-* ]]; then
+    # a full strip breaks Mach-O dylibs/bundles; -x keeps global symbols
+    _stripopt="-x"
+  else
+    # safe for both executables and shared objects; keeps dynamic symbols
+    _stripopt="--strip-unneeded"
+  fi
   local _file
   while IFS= read -r _file; do
     [ -f "${_file}" ] || continue
-    case "$(file -b "${_file}" 2>/dev/null)" in
-      *Mach-O*)
-        # a full strip breaks Mach-O dylibs/bundles; -x keeps global symbols
-        "${_strip}" -x "${_file}" || true
-        ;;
-      *ELF*executable*)
-        "${_strip}" "${_file}" || true
-        ;;
-      *ELF*shared*object*)
-        "${_strip}" --strip-unneeded "${_file}" || true
-        ;;
-    esac
+    "${_strip}" ${_stripopt} "${_file}" 2>/dev/null || true
   done
 }

--- a/recipe/common.sh
+++ b/recipe/common.sh
@@ -47,3 +47,37 @@ HTCONDOR_CMAKE_ARGS="
   -DWITH_VOMS:BOOL=FALSE
   -DWITH_PLACEMENT:BOOL=FALSE
 "
+
+# strip debug symbols from binaries listed on stdin.
+#
+# HTCondor's CMake unconditionally forces a RelWithDebInfo (-O2 -g3) build
+# regardless of the build type we request -- see the plain (non-cache)
+# set() calls in build/cmake/CondorConfigure.cmake, which shadow any
+# -DCMAKE_BUILD_TYPE we pass.  conda-build does not strip binaries itself,
+# so without this every shipped executable and library carries full -g3
+# debug info, which is a significant size overhead.  Upstream expects the
+# packaging system to do the stripping ("package may strip the info").
+#
+# Reads a newline-separated list of paths on stdin and strips any that are
+# ELF/Mach-O binaries (other paths, e.g. scripts and data files, are left
+# untouched).  Uses the toolchain ${STRIP} so it also works when cross
+# compiling.
+condor_strip() {
+  local _strip="${STRIP:-strip}"
+  local _file
+  while IFS= read -r _file; do
+    [ -f "${_file}" ] || continue
+    case "$(file -b "${_file}" 2>/dev/null)" in
+      *Mach-O*)
+        # a full strip breaks Mach-O dylibs/bundles; -x keeps global symbols
+        "${_strip}" -x "${_file}" || true
+        ;;
+      *ELF*executable*)
+        "${_strip}" "${_file}" || true
+        ;;
+      *ELF*shared*object*)
+        "${_strip}" --strip-unneeded "${_file}" || true
+        ;;
+    esac
+  done
+}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ source:
 
 build:
   error_overlinking: true
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
The binaries were shipping with full debug symbols, making the packages much bigger than needed.

HTCondor's CMake always builds with `-g3` and expects whatever packages it to strip the debug info, but conda-build doesn't strip on its own, so it leaked into the final packages. See the upstream comment: [`CondorConfigure.cmake#L339`](https://github.com/htcondor/htcondor/blob/5bea63d046a456df235c30b679cd002a01a38552/build/cmake/CondorConfigure.cmake#L337-L339) (`# = -O2 -g (package may strip the info)`).

This adds a small `condor_strip` helper and runs it over the installed binaries and Python extension modules during the build. Build number bumped so the packages rebuild.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
